### PR TITLE
fix links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 This repo is for **bug reporting** on CodePen in public. You know: things that are broken. 
 
-If you need *private* support, you can [get that here](http://codepen.dev/support/). You know, things like billing and accont specific questions.
+If you need *private* support, you can [get that here](http://codepen.io/support/). You know, things like billing and account specific questions.
 
-Things like **opinions**, **wishes**, and **feedback** are better submitted to us via the [private support form](http://codepen.dev/support/). If you open those kinds of threads here, we will likely close them and triage them over to our side.
+Things like **opinions**, **wishes**, and **feedback** are better submitted to us via the [private support form](http://codepen.io/support/). If you open those kinds of threads here, we will likely close them and triage them over to our side.


### PR DESCRIPTION
The links currently point to `codepen.dev` but should point to `codepen.io` instead.